### PR TITLE
(fix) remove arbitrary version restriction

### DIFF
--- a/monocypher.nimble
+++ b/monocypher.nimble
@@ -7,7 +7,7 @@ license     = "MIT"
 
 # Dependencies
 
-requires "nim >= 1.2.0 & < 2.0.0"
+requires "nim >= 1.2.0"
 requires "nimterop >= 0.6.13 & < 0.7.0"
 
 # Test dependencies


### PR DESCRIPTION
For some reason, you added a line that prevents newer Nim installs (v2.0+) from installing this library. 
Is there any reason to do this, or was this unintentional? All the tests seem to pass properly from what I've done.
